### PR TITLE
Feat: Core Kiosk Mechanics (Device Admin & LockTask)

### DIFF
--- a/WallPanelApp/src/main/AndroidManifest.xml
+++ b/WallPanelApp/src/main/AndroidManifest.xml
@@ -99,6 +99,23 @@
             </intent-filter>
         </receiver>
 
+        <receiver
+            android:name="xyz.wallpanel.app.WallPanelDeviceAdminReceiver"
+            android:description="@string/app_name"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_DEVICE_ADMIN"
+            android:exported="true">
+            <meta-data
+                android:name="android.app.device_admin"
+                android:resource="@xml/device_admin_receiver" />
+
+            <intent-filter>
+                <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
+                <action android:name="android.app.action.DEVICE_ADMIN_DISABLE_REQUESTED" />
+                <action android:name="android.app.action.DEVICE_ADMIN_DISABLED" />
+            </intent-filter>
+        </receiver>
+
         <meta-data
             android:name="com.google.android.gms.vision.DEPENDENCIES"
             android:value="face,barcode" />

--- a/WallPanelApp/src/main/java/xyz/wallpanel/app/WallPanelDeviceAdminReceiver.kt
+++ b/WallPanelApp/src/main/java/xyz/wallpanel/app/WallPanelDeviceAdminReceiver.kt
@@ -1,0 +1,34 @@
+package xyz.wallpanel.app
+
+import android.app.admin.DeviceAdminReceiver
+import android.content.Context
+import android.content.Intent
+import timber.log.Timber
+
+class WallPanelDeviceAdminReceiver : DeviceAdminReceiver() {
+
+    override fun onEnabled(context: Context, intent: Intent) {
+        super.onEnabled(context, intent)
+        Timber.d("Device Admin Enabled")
+    }
+
+    override fun onDisabled(context: Context, intent: Intent) {
+        super.onDisabled(context, intent)
+        Timber.d("Device Admin Disabled")
+    }
+
+    override fun onProfileProvisioningComplete(context: Context, intent: Intent) {
+        super.onProfileProvisioningComplete(context, intent)
+        Timber.d("Profile Provisioning Complete")
+    }
+
+    override fun onLockTaskModeEntering(context: Context, intent: Intent, pkg: String) {
+        super.onLockTaskModeEntering(context, intent, pkg)
+        Timber.d("Lock Task Mode Entering")
+    }
+
+    override fun onLockTaskModeExiting(context: Context, intent: Intent) {
+        super.onLockTaskModeExiting(context, intent)
+        Timber.d("Lock Task Mode Exiting")
+    }
+}

--- a/WallPanelApp/src/main/java/xyz/wallpanel/app/persistence/Configuration.kt
+++ b/WallPanelApp/src/main/java/xyz/wallpanel/app/persistence/Configuration.kt
@@ -65,6 +65,10 @@ constructor(private val context: Context, private val sharedPreferences: SharedP
         get() = this.sharedPreferences.getBoolean(PREF_SETTINGS_DISABLE, false)
         set(value) = this.sharedPreferences.edit().putBoolean(PREF_SETTINGS_DISABLE, value).apply()
 
+    var lockTaskEnabled: Boolean
+        get() = this.sharedPreferences.getBoolean(PREF_LOCK_TASK_ENABLED, false)
+        set(value) = this.sharedPreferences.edit().putBoolean(PREF_LOCK_TASK_ENABLED, value).apply()
+
     var writeScreenPermissionsShown: Boolean
         get() = sharedPreferences.getBoolean(PREF_WRITE_SCREEN_PERMISSIONS, false)
         set(value) {
@@ -391,6 +395,7 @@ constructor(private val context: Context, private val sharedPreferences: SharedP
         private const val PREF_SETTINGS_CODE_STRING = "pref_settings_code_string"
         private const val PREF_SETTINGS_TRANSPARENT = "pref_settings_transparent"
         private const val PREF_SETTINGS_DISABLE = "pref_settings_disable"
+        private const val PREF_LOCK_TASK_ENABLED = "pref_lock_task_enabled"
         private const val PREF_SETTINGS_LOCATION = "pref_settings_location"
         const val PREF_FIRST_TIME = "pref_first_time"
         const val PREF_WRITE_SCREEN_PERMISSIONS = "pref_write_screen_permissions"

--- a/WallPanelApp/src/main/java/xyz/wallpanel/app/ui/activities/BrowserActivityNative.kt
+++ b/WallPanelApp/src/main/java/xyz/wallpanel/app/ui/activities/BrowserActivityNative.kt
@@ -57,6 +57,9 @@ import java.util.concurrent.TimeUnit
 @AndroidEntryPoint
 class BrowserActivityNative : BaseBrowserActivity(), LifecycleObserver, WebClientCallback {
 
+    @Inject
+    lateinit var deviceAdminUtils: xyz.wallpanel.app.utils.DeviceAdminUtils
+
     private lateinit var webView: WebView
     private lateinit var binding: ActivityBrowserBinding
     private var certPermissionsShown = false
@@ -164,6 +167,12 @@ class BrowserActivityNative : BaseBrowserActivity(), LifecycleObserver, WebClien
 
         if (configuration.hasSettingsUpdates()) {
             initWebPageLoad()
+        }
+
+        if (configuration.lockTaskEnabled) {
+            deviceAdminUtils.startLockTask(this)
+        } else {
+            deviceAdminUtils.stopLockTask(this)
         }
     }
 

--- a/WallPanelApp/src/main/java/xyz/wallpanel/app/utils/DeviceAdminUtils.kt
+++ b/WallPanelApp/src/main/java/xyz/wallpanel/app/utils/DeviceAdminUtils.kt
@@ -1,0 +1,71 @@
+package xyz.wallpanel.app.utils
+
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
+import android.content.Context
+import android.os.Build
+import timber.log.Timber
+import xyz.wallpanel.app.WallPanelDeviceAdminReceiver
+import javax.inject.Inject
+
+class DeviceAdminUtils @Inject constructor(private val context: Context) {
+
+    private val devicePolicyManager: DevicePolicyManager by lazy {
+        context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+    }
+
+    private val componentName: ComponentName by lazy {
+        ComponentName(context, WallPanelDeviceAdminReceiver::class.java)
+    }
+
+    fun isDeviceOwner(): Boolean {
+        return devicePolicyManager.isDeviceOwnerApp(context.packageName)
+    }
+
+    fun isAdmin(): Boolean {
+        return devicePolicyManager.isAdminActive(componentName)
+    }
+
+    fun setLockTaskPackages(packages: Array<String>) {
+        if (isDeviceOwner()) {
+            try {
+                devicePolicyManager.setLockTaskPackages(componentName, packages)
+                Timber.d("LockTask packages set: ${packages.joinToString()}")
+            } catch (e: SecurityException) {
+                Timber.e(e, "Error setting LockTask packages")
+            }
+        }
+    }
+
+    fun startLockTask(activity: android.app.Activity) {
+        if (isDeviceOwner()) {
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                     // Ensure the package is allowed to lock task
+                     val currentPackages = devicePolicyManager.getLockTaskPackages(componentName)
+                     if (!currentPackages.contains(context.packageName)) {
+                         setLockTaskPackages(arrayOf(context.packageName))
+                     }
+                } else {
+                     setLockTaskPackages(arrayOf(context.packageName))
+                }
+
+                activity.startLockTask()
+                Timber.d("LockTask started")
+            } catch (e: Exception) {
+                Timber.e(e, "Error starting LockTask")
+            }
+        }
+    }
+
+    fun stopLockTask(activity: android.app.Activity) {
+        if (isDeviceOwner()) {
+            try {
+                activity.stopLockTask()
+                Timber.d("LockTask stopped")
+            } catch (e: Exception) {
+                Timber.e(e, "Error stopping LockTask")
+            }
+        }
+    }
+}

--- a/WallPanelApp/src/main/res/values/strings.xml
+++ b/WallPanelApp/src/main/res/values/strings.xml
@@ -100,6 +100,9 @@
     <string name="pref_title_screen_brightness">Screen Brightness</string>
     <string name="pref_description_screen_brightness">Give permission to the application to control the device\'s screen brightness. Update the device brightness, then click the button to save or update the value.</string>
 
+    <string name="pref_lock_task_mode_title">LockTask Mode</string>
+    <string name="pref_lock_task_mode_summary">Locks the application to the screen (Kiosk Mode). Requires Device Owner privileges.</string>
+
     <string name="toast_write_permissions_denied">Write settings permission denied…</string>
     <string name="toast_write_permissions_granted">Write settings permission granted…</string>
     <string name="pref_http_settings_title">HTTP Settings</string>

--- a/WallPanelApp/src/main/res/xml/device_admin_receiver.xml
+++ b/WallPanelApp/src/main/res/xml/device_admin_receiver.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device-admin xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-policies>
+        <disable-keyguard-features />
+        <force-lock />
+        <limit-password />
+        <watch-login />
+        <reset-password />
+        <wipe-data />
+        <expire-password />
+    </uses-policies>
+</device-admin>

--- a/WallPanelApp/src/main/res/xml/pref_general.xml
+++ b/WallPanelApp/src/main/res/xml/pref_general.xml
@@ -41,6 +41,12 @@
 
         <SwitchPreference
             android:defaultValue="false"
+            android:key="pref_lock_task_enabled"
+            android:title="@string/pref_lock_task_mode_title"
+            android:summary="@string/pref_lock_task_mode_summary"/>
+
+        <SwitchPreference
+            android:defaultValue="false"
             android:key="@string/key_setting_app_showactivity"
             android:summary="@string/pref_show_browser_activity_summary"
             android:title="@string/title_setting_app_showactivity"/>


### PR DESCRIPTION
## Phase 2: Core Kiosk Mechanics

This PR implements key Kiosk features for WallPanel:

### Device Admin Receiver
- Added `WallPanelDeviceAdminReceiver` and `device_admin_receiver.xml` to allow the app to be set as Device Owner by the user (via adb).
- This is a prerequisite for advanced features like Screen Pinning (LockTask), Reboot, etc.

### LockTask (Kiosk) Mode
- Added `DeviceAdminUtils` helper.
- Added "LockTask Mode" toggle in General Settings.
- Updated `BrowserActivityNative` to automatically enter LockTask mode when settings are enabled.
- Ensures the app stays pinned to the screen, preventing user exit (unless via specific admin actions).

### Changes
- `WallPanelDeviceAdminReceiver.kt`: New receiver.
- `DeviceAdminUtils.kt`: New helper for DPM.
- `BrowserActivityNative.kt`: Integration.
- `Configuration.kt` & XMLs: Settings support.

### Verification
- [x] Compilation verified.
- [ ] Manual test required: 
    1. Set Device Owner: `adb shell dpm set-device-owner xyz.wallpanel.app/.WallPanelDeviceAdminReceiver`
    2. Enable "LockTask Mode" in settings.
    3. Verify app pins to screen.